### PR TITLE
Option to click instead of hover to open children

### DIFF
--- a/component/public/bundled/views/actions/actions.js
+++ b/component/public/bundled/views/actions/actions.js
@@ -119,6 +119,9 @@ nabu.page.views.PageActions = Vue.component("page-actions", {
 			if (!state.useButtons) {
 				Vue.set(state, "useButtons", false);	
 			}
+			if (!state.useClick) {
+				Vue.set(state, "useClick", false);	
+			}			
 			state.actions.map(function(action) {
 				if (!action.activeRoutes) {
 					Vue.set(action, "activeRoutes", []);
@@ -170,14 +173,27 @@ nabu.page.views.PageActions = Vue.component("page-actions", {
 		},
 		hide: function(action) {
 			var index = this.showing.indexOf(action);
-			if (index >= 0) {
+			if (!this.cell.state.useClick && index >= 0) {
 				this.showing.splice(index, 1);
 			}
 		},
 		show: function(action) {
-			if (this.showing.indexOf(action) < 0) {
+			if (!this.cell.state.useClick && this.showing.indexOf(action) < 0) {
 				this.showing.push(action);
 			}
+		},
+		toggle: function(action) {
+			var index = this.showing.indexOf(action);
+			if (index < 0) {
+				this.showing.push(action);
+			}
+			else {
+				this.showing.splice(index, 1);
+			}
+		},
+		closeAll: function() {
+			this.showing.splice(0, this.showing.length);
+			this.$emit("close");
 		},
 		listRoutes: function(value, includeValue) {
 			var routes = this.$services.router.list().map(function(x) { return x.alias });
@@ -218,6 +234,7 @@ nabu.page.views.PageActions = Vue.component("page-actions", {
 		},
 		handle: function(action, force) {
 			if (force || !this.isDisabled(action)) {
+				this.closeAll();
 				if (action.route) {
 					var route = action.route;
 					if (route.charAt(0) == "=") {

--- a/component/public/bundled/views/actions/actions.tpl
+++ b/component/public/bundled/views/actions/actions.tpl
@@ -8,6 +8,7 @@
 							:filter="function(value) { return $services.page.classes('page-actions', value) }"/>
 						<n-form-text v-model="cell.state.activeClass" label="Active Class"/>
 						<n-form-switch v-model="cell.state.useButtons" label="Use Buttons"/>
+						<n-form-switch v-model="cell.state.useClick" label="Click to open children"/>
 						<n-form-combo v-model="cell.state.defaultAction" label="Default Action"
 							:filter="function() { return cell.state.actions.map(function(x) { return x.label }) }"/>
 					</n-collapsible>
@@ -57,7 +58,7 @@
 		<li v-for="action in getActions()" v-if="isVisible(action)"
 				class="page-action"
 				:class="[{ 'has-children': action.actions.length }, action.class]"
-				@mouseover="show(action)" @mouseout="hide(action)"
+				@mouseover="show(action)" @mouseout="hide(action)" @click.stop="toggle(action)"
 				:sequence="getActions().indexOf(action) + 1">
 			<span v-if="edit" class="fa fa-cog" @click="configureAction(action)"></span>
 			<a auto-close-actions class="page-action-link page-action-entry" href="javascript:void(0)"


### PR DESCRIPTION
Voor tablet en mobile menu moet de menu opengeklikt worden ipv op basis van hover.

Heb settings parameter toegevoegd: 
switch: click to open children (default false)
+ nodige extra functionaliteit

Enige ding waar ik over twijfel (maar op dit moment wel getest heb is regeltje 237 op de juiste plaats staat